### PR TITLE
Add authentication state management to Create component

### DIFF
--- a/Components/Pages/Create.razor
+++ b/Components/Pages/Create.razor
@@ -1,7 +1,9 @@
 @page "/create"
+@using Microsoft.AspNetCore.Components.Authorization
 @using flashcard.model
 @using flashcard.utils
 @inject FlashCardService FlashCardService
+@inject AuthenticationStateProvider AuthenticationStateProvider
 @rendermode InteractiveServer
 
 <PageTitle>Create a Flashcard</PageTitle>

--- a/Components/Pages/Create.razor.cs
+++ b/Components/Pages/Create.razor.cs
@@ -1,21 +1,23 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
 
 namespace flashcard.Components.Pages
 {
 	public partial class Create : ComponentBase
 	{
-		[CascadingParameter]
-		public required HttpContext HttpContext { get; set; }
-
 		[Inject]
 		public required NavigationManager NavigationManager { get; set; }
 
-		protected override void OnInitialized()
+		private AuthenticationState? _authenticationState;
+
+		protected override async Task OnInitializedAsync()
 		{
-			if (!HttpContext.User.Identity!.IsAuthenticated)
+			_authenticationState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+			var user = _authenticationState.User;
+
+			if (user.Identity == null || !user.Identity.IsAuthenticated)
 			{
 				NavigationManager.NavigateTo("/auth/signin");
-				return;
 			}
 		}
 


### PR DESCRIPTION
Introduce authentication state management in Create.razor and Create.razor.cs.
- Inject AuthenticationStateProvider in Create.razor.
- Remove HttpContext property from Create.razor.cs.
- Replace OnInitialized with OnInitializedAsync.
- Redirect unauthenticated users to the sign-in page.